### PR TITLE
fix passing argument 1 of 'ohm_value_from_pointer' makes pointer from integer without a cast

### DIFF
--- a/tests/test-fact.c
+++ b/tests/test-fact.c
@@ -73,7 +73,7 @@ static void _structure_set_get(OhmStructure* s)
     ohm_structure_set(s, "field2", NULL);
     v = ((GValue*) ohm_structure_get(s, "field2"));
     fail_unless(v == NULL);
-    ohm_structure_set(s, "pointer1", ohm_value_from_pointer(0xdeadbeef));
+    ohm_structure_set(s, "pointer1", ohm_value_from_pointer((void*)0xdeadbeef));
     v = ohm_structure_get(s, "pointer1");
     fail_unless(v != NULL);
     fail_unless(g_value_get_pointer(v) == 0xdeadbeef);
@@ -107,7 +107,7 @@ START_TEST (test_fact_structure_to_string)
 {
     OhmStructure* s;
     char* _tmp;
-    void* _ptr = 0xdeadbeef;
+    void* _ptr = (void*)0xdeadbeef;
 
     s = ohm_structure_new("org.freedesktop.ohm.test");
     ohm_structure_set(s, "field1", ohm_value_from_string("test1"));


### PR DESCRIPTION
It seems manjaro have -Wint-conversion as default now:

this behaviour comes with 
gcc 14 see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106416
clang 15 see https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html

```
gcc -DHAVE_CONFIG_H -I. -I..  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/sysprof-6 -pthread -DVERSION_MAJOR=1 -DVERSION_MINOR=1 -DVERSION_PATCH=1 -DSYSCONFDIR=\"/etc\" -I../include -Wall -Wcast-align -Wno-uninitialized -fno-strict-aliasing  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection         -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/nemo-packaging/ohm/src=/usr/src/debug/ohm -MT test-fact.o -MD -MP -MF .deps/test-fact.Tpo -c -o test-fact.o test-fact.c
In file included from test-fact.c:7:
test-fact.c: In function '_structure_set_get':
test-fact.c:60:14: warning: zero-length gnu_printf format string [-Wformat-zero-length]
   60 |         fail("");
      |              ^~
test-fact.c:76:61: error: passing argument 1 of 'ohm_value_from_pointer' makes pointer from integer without a cast [-Wint-conversion]
   76 |     ohm_structure_set(s, "pointer1", ohm_value_from_pointer(0xdeadbeef));
      |                                                             ^~~~~~~~~~
      |                                                             |
      |                                                             unsigned int
In file included from ../include/ohm/ohm-fact.h:6,
                 from test-fact.c:3:
../include/ohm/ohm-factstore.h:430:42: note: expected 'gpointer' {aka 'void *'} but argument is of type 'unsigned int'
  430 | GValue* ohm_value_from_pointer (gpointer pointer);
      |                                 ~~~~~~~~~^~~~~~~
test-fact.c:79:40: warning: comparison between pointer and integer
   79 |     fail_unless(g_value_get_pointer(v) == 0xdeadbeef);
      |                                        ^~
test-fact.c: In function 'test_fact_structure_to_string_fn':
test-fact.c:110:18: error: initialization of 'void *' from 'unsigned int' makes pointer from integer without a cast [-Wint-conversion]
  110 |     void* _ptr = 0xdeadbeef;
      |                  ^~~~~~~~~~
make[2]: *** [Makefile:406: test-fact.o] Error 1
make[2]: Leaving directory '/nemo-packaging/ohm/src/ohm-1.3.1/tests'
make[1]: *** [Makefile:555: all-recursive] Error 1
make[1]: Leaving directory '/nemo-packaging/ohm/src/ohm-1.3.1'
make: *** [Makefile:443: all] Error 2
```